### PR TITLE
Inlining p-defer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ### Changed
 - Updated to `@babel/core@7.1.2` and `jest@23.6.0`
 - Use `p-defer` for deferred implementation
+   - Instead of importing `p-defer` package, we copied the code in
+      - `p-defer` package published to NPM is not ES5-compliant
+      - Non ES5-compliant package will fail build for `create-react-app@1`
 
 ## [1.0.3] - 2018-06-28
 ### Fixed

--- a/package-lock.json
+++ b/package-lock.json
@@ -5893,11 +5893,6 @@
         "mkdirp": "^0.5.1"
       }
     },
-    "p-defer": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/p-defer/-/p-defer-1.0.0.tgz",
-      "integrity": "sha1-n26xgvbJqozXQwBKfU+WsZaw+ww="
-    },
     "p-finally": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/p-finally/-/p-finally-1.0.0.tgz",

--- a/package.json
+++ b/package.json
@@ -48,8 +48,5 @@
     "redux": "^4.0.0",
     "redux-saga": "^0.16.0",
     "rimraf": "^2.6.2"
-  },
-  "dependencies": {
-    "p-defer": "^1.0.0"
   }
 }

--- a/src/external/p-defer.js
+++ b/src/external/p-defer.js
@@ -1,0 +1,46 @@
+// The MIT License (MIT)
+//
+// Copyright (c) Sindre Sorhus <sindresorhus@gmail.com> (sindresorhus.com)
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+// This piece of code is adopted from https://github.com/sindresorhus/p-defer
+
+// The reason why we need to fork it is because:
+// - The original package published to NPM is not ES5-compliant
+//    - Due to the use of arrow functions
+// - create-react-app@1 does not play nice with packages that are not ES5-compliant
+//    - create-react-app@2 do play nice, but it was so new that most of the people are still on @1
+
+// Criteria to remove this package:
+// - When create-react-app@2 become mainstream, or,
+// - When p-defer start publishing a ES5-compliant version on NPM
+
+'use strict';
+
+module.exports = function () {
+  const ret = {};
+
+  ret.promise = new Promise(function (resolve, reject) {
+    ret.resolve = resolve;
+    ret.reject = reject;
+  });
+
+  return ret;
+};

--- a/src/index.js
+++ b/src/index.js
@@ -1,4 +1,4 @@
-import createDeferred from 'p-defer';
+import createDeferred from './external/p-defer';
 
 export default class EventAsPromise {
   constructor(options = {}) {


### PR DESCRIPTION
- Instead of importing `p-defer` package, we copied the code in 
   - `p-defer` package published to NPM is not ES5-compliant 
   - Non ES5-compliant package will fail build for `create-react-app@1`